### PR TITLE
Refresh homepage pricing, features, and copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Marketing site for Deploys.app (a Kubernetes-based PaaS), built with **Hugo extended 0.137.1** (pinned via `.tool-versions` — use `asdf install`). Deploys as a static site to Cloudflare Pages (see `static/_headers`).
+
+## Commands
+
+- `make dev` — run local Hugo server with live reload (`hugo server`).
+- `make build` — produce static output in `/public/`.
+
+There are no tests, linters, or JS toolchain. Hugo invokes Dart Sass for SCSS via `css.Sass`, so the extended build is required.
+
+## Architecture
+
+### Content vs. layouts
+
+Most of the site is **not** content-driven. The homepage (`/`) is hand-authored in `layouts/index.html` — sections (hero, features, pricing, CTA) are hard-coded HTML, not loops over content files. The only Markdown content lives in `content/privacy-policy/index.md` and renders through `layouts/_default/single.html`. `layouts/_default/baseof.html` is the shared shell (head, font-awesome CDN, compiled SCSS, navbar partial). New marketing copy on the homepage means editing `layouts/index.html` directly.
+
+Taxonomies are disabled in `config.yaml` (`disableKinds: [taxonomy]` + the matching `ignoreErrors`); don't reintroduce them without updating both keys.
+
+### Styling system (custom atomic CSS)
+
+`assets/style/` is a bespoke utility-first CSS framework, compiled by Hugo Pipes (`css.Sass | resources.Minify | resources.Fingerprint`). The structure is layered and the order in `main.scss` is load-bearing — `theme` defines CSS custom properties that the atomic classes consume.
+
+- `atomic/` — single-property utilities prefixed with `_` (the `$atom-prefix` in `atomic/config.scss`). Naming is abbreviated: `_mgbt-16px` (margin-bottom), `_dp-f` (display:flex), `_cl-neutral-500` (color), `_fs-700` (font-size), `_gg-16px` (grid-gap), `_jtfct-spbtw` (justify-content:space-between), `_pdt-70px` (padding-top), `_als-ct` (align-self:center). Every atomic also auto-generates breakpoint variants: `_dp-n-lg` = `display:none` at `lg` and up.
+- `layout/` — `lo-container`, `lo-12`/`lo-6-md`/`lo-4-lg` grid spans. The grid is mobile-first with `-md`/`-lg` overrides.
+- `component/` — `moon-*` and named components: `moon-navbar`, `moon-button`, `fancy-box`, `fancy-icon`, `section`, etc.
+- `utility/`, `mixins/`, `function/` — animation helpers, typography, breakpoint mixin.
+
+When adding styles, prefer composing existing atomics in markup over writing new CSS. Reach for a new component class only when a pattern repeats and needs semantic naming.
+
+### Theme tokens
+
+`assets/style/_theme.scss` defines all color/spacing/typography as CSS custom properties (`--color-primary-500`, `--color-neutral-700`, etc.). `atomic/config.scss` maps these into `$colors`/`$spacings`/etc. so atomic classes resolve to the CSS variables. To add a color or size scale, add it in `_theme.scss` and the corresponding map in `atomic/config.scss`.
+
+### Interactivity
+
+No bundler, no framework. Two scripts are used:
+- **hyperscript** (loaded from unpkg in `baseof.html`) — inline `_="on click ..."` attributes drive small interactions (e.g. navbar toggle in `layouts/partials/navbar.html`).
+- A small inline `<script>` in `navbar.html` adds the scroll-fixed navbar behavior.
+
+Font Awesome Pro CSS is loaded from `cdn.moonrhythm.io`.
+
+### Static assets and caching
+
+Long-lived assets go through Hugo's pipeline with `resources.Fingerprint` (cache-busted filenames). `static/_headers` sets `cache-control: public, max-age=31536000, immutable` for `/image/*`, `/style/*`, `/fonts/*` and adds `x-robots-tag: noindex` to `*.pages.dev` preview URLs — keep that header in place so previews stay out of search indexes.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -186,7 +186,7 @@
 					<thead>
 					<tr>
 						<th class="_tal-ct">RESOURCE</th>
-						<th class="_tal-ct">VALUE</th>
+						<th class="_tal-ct">UNIT</th>
 						<th class="_tal-ct">PRICE</th>
 					</tr>
 					</thead>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,10 +5,10 @@
 		<div class="lo-12 lo-6-md _gg-32px">
 			<div class="_dp-f _fdrt-cl _jtfct-ct">
 				<h1 class="_fw-700 _fs-1300-lg _fs-1100 _cl-white _mgbt-16px">
-					Deploy and run containers!
+					Deploy and run containers with confidence.
 				</h1>
-				<p class="_fs-500 _fw-500 _cl-white _mgbt-48px">Deploys.app is a platform as a service based on Kubernetes for run containers on the cloud.</p>
-				<a class="moon-button _als-fst-lg _als-ct" href="/#price">Get your plans</a>
+				<p class="_fs-500 _fw-500 _cl-white _mgbt-48px">Deploys.app is a Kubernetes-based platform-as-a-service for running containerized workloads in the cloud.</p>
+				<a class="moon-button _als-fst-lg _als-ct" href="/#price">View pricing</a>
 			</div>
 			<div class="_mgt-16px">
 				<img class="_w-100pct" src="{{ (resources.Get "image/database.svg" | resources.Fingerprint).RelPermalink }}" alt="Server Architecture">
@@ -30,42 +30,42 @@
 					<i class="fa-light fa-server"></i>
 				</div>
 				<h3 class="_cl-neutral-500 _fw-700 _mgbt-18px _fs-700">Web Service</h3>
-				<p class="_fw-500 _cl-dark-secondary">Running service that expose HTTPS to the internet.</p>
+				<p class="_fw-500 _cl-dark-secondary">Run services that expose secure HTTPS endpoints to the internet.</p>
 			</div>
 			<div class="fancy-box">
 				<div class="fancy-icon">
 					<i class="fa-light fa-database"></i>
 				</div>
 				<h3 class="_cl-neutral-500 _fw-700 _mgbt-18px _fs-700">TCP Service</h3>
-				<p class="_fw-500 _cl-dark-secondary">Running internal TCP service.</p>
+				<p class="_fw-500 _cl-dark-secondary">Run internal TCP services within your private network.</p>
 			</div>
 			<div class="fancy-box">
 				<div class="fancy-icon">
 					<i class="fa-light fa-microchip"></i>
 				</div>
 				<h3 class="_cl-neutral-500 _fw-700 _mgbt-18px _fs-700">Worker</h3>
-				<p class="_fw-500 _cl-dark-secondary">Running background worker service.</p>
+				<p class="_fw-500 _cl-dark-secondary">Run long-running background workers and queue consumers.</p>
 			</div>
 			<div class="fancy-box">
 				<div class="fancy-icon">
 					<i class="fa-light fa-suitcase"></i>
 				</div>
 				<h3 class="_cl-neutral-500 _fw-700 _mgbt-18px _fs-700">Cron Job</h3>
-				<p class="_fw-500 _cl-dark-secondary">Running service with start scheduler.</p>
+				<p class="_fw-500 _cl-dark-secondary">Run scheduled tasks on a flexible cron schedule.</p>
 			</div>
 			<div class="fancy-box">
 				<div class="fancy-icon">
 					<i class="fa-light fa-disc-drive"></i>
 				</div>
 				<h3 class="_cl-neutral-500 _fw-700 _mgbt-18px _fs-700">Stateful and Stateless</h3>
-				<p class="_fw-500 _cl-dark-secondary">Support both stateless and stateful service with SSD.</p>
+				<p class="_fw-500 _cl-dark-secondary">Support both stateless and stateful workloads, backed by persistent SSD storage.</p>
 			</div>
 			<div class="fancy-box">
 				<div class="fancy-icon">
-					<i class="fa-brands fa-cloudflare"></i>
+					<i class="fa-brands fa-docker"></i>
 				</div>
-				<h3 class="_cl-neutral-500 _fw-700 _mgbt-18px _fs-700">DDoS Protection</h3>
-				<p class="_fw-500 _cl-dark-secondary">CDN Domains protected by Cloudflare Enterprise.</p>
+				<h3 class="_cl-neutral-500 _fw-700 _mgbt-18px _fs-700">Docker Registry</h3>
+				<p class="_fw-500 _cl-dark-secondary">Built-in private container registry for storing and distributing your images.</p>
 			</div>
 		</div>
 	</div>
@@ -79,12 +79,12 @@
 			</div>
 			<div>
 				<h2 class="_fw-700 _fs-1000 _fs-1100-lg _cl-neutral-500 _mgbt-16px">
-					Solutions for Your small
+					Solutions for
 					<br>
-					business
+					small businesses
 				</h2>
 				<p class="_cl-neutral-500 _mgbt-32px">
-					Running containers in shared Kubernetes nodes to reduce infrastructure cost.
+					Run containers on shared Kubernetes nodes to minimize infrastructure costs.
 				</p>
 				<div class="fancy-box-2 _mgbt-24px">
 					<div class="fancy-icon">
@@ -92,7 +92,7 @@
 					</div>
 					<div class="fancy-body">
 						<h4 class="_fw-500 _cl-neutral-500 _mgbt-8px">Pay as you go</h4>
-						<p class="_cl-neutral-500">Pay only resource you use, not whole server.</p>
+						<p class="_cl-neutral-500">Pay only for the resources you use — never for an entire server.</p>
 					</div>
 				</div>
 				<div class="fancy-box-2 _mgbt-24px">
@@ -101,7 +101,7 @@
 					</div>
 					<div class="fancy-body">
 						<h4 class="_fw-500 _cl-neutral-500 _mgbt-8px">Move faster</h4>
-						<p class="_cl-neutral-500">Deploys.app CLI can use in CI/CD system to automated deploy.</p>
+						<p class="_cl-neutral-500">Integrate the Deploys.app CLI into your CI/CD pipeline for fully automated deployments.</p>
 					</div>
 				</div>
 			</div>
@@ -114,12 +114,12 @@
 		<div class="lo-12 lo-6-md _gg-24px">
 			<div class="_od-2 _od-1-lg">
 				<h2 class="_fw-700 _fs-1000 _fs-1100-lg _cl-neutral-500 _mgbt-16px">
-					Solutions for Your big
+					Solutions for
 					<br>
-					business
+					enterprises
 				</h2>
 				<p class="_cl-neutral-500 _mgbt-32px">
-					Separate workloads on your own nodes.
+					Isolate workloads on dedicated nodes you control.
 				</p>
 				<div class="fancy-box-2 _mgbt-24px">
 					<div class="fancy-icon">
@@ -127,7 +127,7 @@
 					</div>
 					<div class="fancy-body">
 						<h4 class="_fw-500 _cl-neutral-500 _mgbt-8px">Allocated resources</h4>
-						<p class="_cl-neutral-500">Allocated resources to not shared with anyone. And can also reduce price.!</p>
+						<p class="_cl-neutral-500">Dedicated resources reserved exclusively for your workloads, with lower per-unit pricing at scale.</p>
 					</div>
 				</div>
 				<div class="fancy-box-2 _mgbt-24px">
@@ -136,7 +136,7 @@
 					</div>
 					<div class="fancy-body">
 						<h4 class="_fw-500 _cl-neutral-500 _mgbt-8px">Bring your own Kubernetes</h4>
-						<p class="_cl-neutral-500">Deploys.app Agent can run on your Kubernetes cluster.</p>
+						<p class="_cl-neutral-500">Run the Deploys.app Agent on your own Kubernetes cluster.</p>
 					</div>
 				</div>
 			</div>
@@ -159,9 +159,9 @@
 					Deploy to multiple regions
 				</h2>
 				<p class="_cl-white _mgbt-32px">
-					Deploys your workloads to any regions. (will available more in the future)
+					Deploy your workloads across multiple regions, with additional locations coming soon.
 				</p>
-				<a class="moon-button _als-fst" href="https://console.deploys.app">Get Start</a>
+				<a class="moon-button _als-fst" href="https://console.deploys.app">Get started</a>
 			</div>
 		</div>
 	</div>
@@ -171,13 +171,11 @@
 	<div class="lo-container">
 		<div>
 			<h2 class="_fw-700 _tal-ct _fs-1100 _fs-1300-lg _cl-neutral-500 _mgbt-16px">
-				Check out plans,
-				<br>
-				And running a container now
+				Simple, usage-based pricing
 			</h2>
 			<p class="_cl-neutral-500 _tal-ct _mgbt-32px">
-				Pay as you go without minimum cost.!<br>
-				All prices VAT included.
+				Pay only for what you use — no minimum commitments.<br>
+				All prices include VAT.
 			</p>
 		</div>
 		<div>
@@ -190,7 +188,6 @@
 						<th class="_tal-ct">RESOURCE</th>
 						<th class="_tal-ct">VALUE</th>
 						<th class="_tal-ct">PRICE</th>
-						<th class="_tal-ct">FREE TIER<br>(Daily)</th>
 					</tr>
 					</thead>
 					<tbody>
@@ -201,7 +198,6 @@
 							<div><strong>฿{{mul $p.cpuUsage $m | lang.FormatNumber 2}}/mo</strong></div>
 							<div>฿{{$p.cpuUsage | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 						</td>
-						<td class="_tal-ct _cl-neutral-400"><strong>{{8640 | lang.FormatNumber 0}} s</strong></td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>Memory</strong></td>
@@ -209,7 +205,6 @@
 						<td class="_tal-ct _cl-neutral-400">
 							<div><strong>Free</strong></div>
 						</td>
-						<td class="_tal-ct _cl-neutral-400">-</td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>Allocated Memory</strong></td>
@@ -218,7 +213,6 @@
 							<div><strong>฿{{mul $p.memory $m | lang.FormatNumber 2}}/mo</strong></div>
 							<div>฿{{$p.memory | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 						</td>
-						<td class="_tal-ct _cl-neutral-400">-</td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>SSD Disk</strong></td>
@@ -227,7 +221,6 @@
 							<div><strong>฿{{mul $p.disk $m | lang.FormatNumber 2}}/mo</strong></div>
 							<div>฿{{$p.disk | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 						</td>
-						<td class="_tal-ct _cl-neutral-400">-</td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>Replica</strong></td>
@@ -236,7 +229,6 @@
 							<div><strong>฿{{mul $p.replica $m | lang.FormatNumber 2}}/mo</strong></div>
 							<div>฿{{$p.replica | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 						</td>
-						<td class="_tal-ct _cl-neutral-400"><strong>{{216000 | lang.FormatNumber 0}} s</strong></td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>Egress Bandwidth</strong></td>
@@ -244,18 +236,14 @@
 						<td class="_tal-ct _cl-neutral-400">
 							<div><strong>฿{{$p.egress | lang.FormatNumber 2}}</strong></div>
 						</td>
-						<td class="_tal-ct _cl-neutral-400">
-							<div><strong>1 GiB</strong> <span class="_fs-100">Uncached</span></div>
-							<div><strong>1 GiB</strong> <span class="_fs-100">Cached</span></div>
-						</td>
 					</tr>
 						<tr>
 							<td class="_tal-ct _cl-neutral-400"><strong>CDN</strong></td>
 							<td class="_tal-ct _cl-neutral-400">1 Domain</td>
 							<td class="_tal-ct _cl-neutral-400">
-								<div><strong>฿{{$p.domainCdn | lang.FormatNumber 2}}/mo</strong></div>
+								<div><strong>฿{{mul $p.domainCdn $m | lang.FormatNumber 2}}/mo</strong></div>
+								<div>฿{{$p.domainCdn | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 							</td>
-							<td class="_tal-ct _cl-neutral-400">-</td>
 						</tr>
 					</tbody>
 				</table>
@@ -269,9 +257,9 @@
 		<div class="lo-12 lo-8-4-md">
 			<div class="_dp-f _fdrt-cl _jtfct-ct">
 				<h4 class="_fw-700 _tal-ct _fs-900 _fs-1100-lg _cl-white _mgbt-16px">
-					Start growing with Deploys.app today!
+					Start building with Deploys.app today.
 				</h4>
-				<p class="_cl-white _tal-ct">30-day moneyback guarantee. No questions asked.</p>
+				<p class="_cl-white _tal-ct">30-day money-back guarantee — no questions asked.</p>
 			</div>
 			<div class="_dp-f _fdrt-cl _jtfct-ct _mgt-16px _mgt-0px-lg">
 				<a class="moon-button _als-ct _als-fe-lg _cl-primary-500 _bgcl-white" href="mailto:contact@moonrhythm.io">Contact us</a>


### PR DESCRIPTION
## Summary
- **Pricing table**: CDN domain price now uses the per-second API value (multiplied by `$m` for the displayed `/mo`, raw value for `/s`) to match how CPU/memory/disk/replica are handled. Removed the `FREE TIER (Daily)` column.
- **Feature cards**: Replaced *DDoS Protection* with *Docker Registry* (uses the `fa-brands fa-docker` icon).
- **Copy polish**: Rewrote hero subhead, every feature card description, the small-business and enterprise segment sections, the multi-region blurb, the pricing heading/subheading, and the final CTA for clarity, grammar, and consistent voice.
- **Tooling**: Added `CLAUDE.md` documenting the Hugo setup, custom atomic CSS framework (`assets/style/atomic/*`), and the hand-authored-homepage model so future Claude Code sessions can ramp quickly.

## Reviewer notes
- The CDN domain row previously displayed `$p.domainCdn` raw — that produced an incorrect monthly figure once the billing API switched its unit. After this change the per-second value flows through the same `mul ... $m` pattern as the other resources.
- No content files were added; the homepage continues to live entirely in `layouts/index.html`.
- No SCSS or layout-class changes — only markup text and one icon swap.

## Test plan
- [ ] `make dev` and open `/` — verify hero, feature grid (Docker Registry card with Docker icon), segment sections, and CTA render with the new copy
- [ ] Scroll to `#price` — confirm pricing table has no FREE TIER column and the CDN row shows two lines (`/mo` and `/s`) matching CPU/memory/disk/replica
- [ ] Confirm the rendered monthly CDN price is plausible (per-second × 60·60·24·30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)