### PR TITLE
Restore FREE TIER (Daily) column in pricing table

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -188,6 +188,7 @@
 						<th class="_tal-ct">RESOURCE</th>
 						<th class="_tal-ct">UNIT</th>
 						<th class="_tal-ct">PRICE</th>
+						<th class="_tal-ct">FREE TIER<br>(Daily)</th>
 					</tr>
 					</thead>
 					<tbody>
@@ -198,6 +199,7 @@
 							<div><strong>฿{{mul $p.cpuUsage $m | lang.FormatNumber 2}}/mo</strong></div>
 							<div>฿{{$p.cpuUsage | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 						</td>
+						<td class="_tal-ct _cl-neutral-400"><strong>{{8640 | lang.FormatNumber 0}} s</strong></td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>Memory</strong></td>
@@ -205,6 +207,7 @@
 						<td class="_tal-ct _cl-neutral-400">
 							<div><strong>Free</strong></div>
 						</td>
+						<td class="_tal-ct _cl-neutral-400">-</td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>Allocated Memory</strong></td>
@@ -213,6 +216,7 @@
 							<div><strong>฿{{mul $p.memory $m | lang.FormatNumber 2}}/mo</strong></div>
 							<div>฿{{$p.memory | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 						</td>
+						<td class="_tal-ct _cl-neutral-400">-</td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>SSD Disk</strong></td>
@@ -221,6 +225,7 @@
 							<div><strong>฿{{mul $p.disk $m | lang.FormatNumber 2}}/mo</strong></div>
 							<div>฿{{$p.disk | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 						</td>
+						<td class="_tal-ct _cl-neutral-400">-</td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>Replica</strong></td>
@@ -229,12 +234,17 @@
 							<div><strong>฿{{mul $p.replica $m | lang.FormatNumber 2}}/mo</strong></div>
 							<div>฿{{$p.replica | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 						</td>
+						<td class="_tal-ct _cl-neutral-400"><strong>{{216000 | lang.FormatNumber 0}} s</strong></td>
 					</tr>
 					<tr>
 						<td class="_tal-ct _cl-neutral-400"><strong>Egress Bandwidth</strong></td>
 						<td class="_tal-ct _cl-neutral-400">1 GiB</td>
 						<td class="_tal-ct _cl-neutral-400">
 							<div><strong>฿{{$p.egress | lang.FormatNumber 2}}</strong></div>
+						</td>
+						<td class="_tal-ct _cl-neutral-400">
+							<div><strong>1 GiB</strong> <span class="_fs-100">Uncached</span></div>
+							<div><strong>1 GiB</strong> <span class="_fs-100">Cached</span></div>
 						</td>
 					</tr>
 						<tr>
@@ -244,6 +254,7 @@
 								<div><strong>฿{{mul $p.domainCdn $m | lang.FormatNumber 2}}/mo</strong></div>
 								<div>฿{{$p.domainCdn | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
 							</td>
+							<td class="_tal-ct _cl-neutral-400">-</td>
 						</tr>
 					</tbody>
 				</table>


### PR DESCRIPTION
## Summary

Bring back the **FREE TIER (Daily)** column on the homepage pricing table that was removed in #7. The free-tier allowances are a useful signal for visitors deciding whether to try the platform, so they should be visible alongside the per-unit prices.

Restored values (matching the pre-refresh table):
- **CPU** — 8,640 s/day
- **Egress Bandwidth** — 1 GiB uncached + 1 GiB cached / day
- **Replica** — 216,000 s/day
- Other rows show `-` to keep the column aligned.

## Test plan

- [ ] `make dev` and confirm the pricing table renders four columns with the expected free-tier values
- [ ] Verify mobile layout still fits the extra column (table is inside `moon-table-container`, which scrolls horizontally)

---
_Generated by [Claude Code](https://claude.ai/code/session_018qzrzL3vZKjfBrmgzD2hp2)_