### PR TITLE
Add Registry Egress row to pricing table

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -247,6 +247,14 @@
 							<div><strong>1 GiB</strong> <span class="_fs-100">Cached</span></div>
 						</td>
 					</tr>
+					<tr>
+						<td class="_tal-ct _cl-neutral-400"><strong>Registry Egress Bandwidth</strong></td>
+						<td class="_tal-ct _cl-neutral-400">1 GiB</td>
+						<td class="_tal-ct _cl-neutral-400">
+							<div><strong>฿{{$p.registryEgress | lang.FormatNumber 2}}</strong></div>
+						</td>
+						<td class="_tal-ct _cl-neutral-400"><strong>1 GiB</strong></td>
+					</tr>
 						<tr>
 							<td class="_tal-ct _cl-neutral-400"><strong>CDN</strong></td>
 							<td class="_tal-ct _cl-neutral-400">1 Domain</td>


### PR DESCRIPTION
## Summary
- Adds a **Registry Egress Bandwidth** row to the homepage pricing table, priced via the new `registryEgress` SKU (1 THB/GiB) with a 1 GiB/day free tier.
- Mirrors [deploys-app/api#11](https://github.com/deploys-app/api/pull/11), which added `PriceRegistryEgress` and `BillingSKUs.RegistryEgress`.

## Test plan
- [ ] Verify the new row renders between **Egress Bandwidth** and **CDN** on the homepage pricing table.
- [ ] Confirm the price column reads from `\$p.registryEgress` and displays `฿1.00` once the api `/billing.skus` endpoint serves the new field.
- [ ] Free tier column shows **1 GiB**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)