### PR TITLE
Add dropbox egress to pricing table

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -255,6 +255,14 @@
 						</td>
 						<td class="_tal-ct _cl-neutral-400"><strong>1 GiB</strong></td>
 					</tr>
+					<tr>
+						<td class="_tal-ct _cl-neutral-400"><strong>Dropbox Egress Bandwidth</strong></td>
+						<td class="_tal-ct _cl-neutral-400">1 GiB</td>
+						<td class="_tal-ct _cl-neutral-400">
+							<div><strong>฿{{$p.dropboxEgress | lang.FormatNumber 2}}</strong></div>
+						</td>
+						<td class="_tal-ct _cl-neutral-400">-</td>
+					</tr>
 						<tr>
 							<td class="_tal-ct _cl-neutral-400"><strong>CDN</strong></td>
 							<td class="_tal-ct _cl-neutral-400">1 Domain</td>


### PR DESCRIPTION
## Summary
- Add a **Dropbox Egress Bandwidth** row to the homepage pricing table, priced from `billing.skus` (`$p.dropboxEgress`), 1 GiB unit, no free tier.

## Notes
- The table fetches `https://api.deploys.app/billing.skus` at build time. `dropboxEgress` only appears once apiserver (deploys-app/apiserver#49) is deployed; until then the row renders **฿0.00**. Deploy/rebuild the site after apiserver ships.

## Test plan
- [x] `hugo --minify` builds clean; row renders ฿0.00 now, ฿1.00 against an API that returns `dropboxEgress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)