### PR TITLE
Upgrade Hugo extended to 0.161.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-hugo extended_0.137.1
+hugo extended_0.161.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Marketing site for Deploys.app (a Kubernetes-based PaaS), built with **Hugo extended 0.137.1** (pinned via `.tool-versions` — use `asdf install`). Deploys as a static site to Cloudflare Pages (see `static/_headers`).
+Marketing site for Deploys.app (a Kubernetes-based PaaS), built with **Hugo extended 0.161.1** (pinned via `.tool-versions` — use `asdf install`). Deploys as a static site to Cloudflare Pages (see `static/_headers`).
 
 ## Commands
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 baseURL: 'https://www.deploys.app/'
-languageCode: 'en-us'
+locale: 'en-us'
 title: 'Deploys.app'
 disableKinds:
 - taxonomy


### PR DESCRIPTION
## Summary
- Bump pinned toolchain in `.tool-versions`: `hugo extended_0.137.1` → `extended_0.161.1` (and the CLAUDE.md reference).
- Replace the `languageCode` site config key (deprecated in Hugo v0.158.0) with `locale` to clear the deprecation warning.

## Testing
- Built locally with the official `hugo_extended_0.161.1` binary (`hugo v0.161.1+extended darwin/arm64`).
- `hugo --gc --minify` completes clean: **no errors, no warnings, no deprecations**; 5 pages + RSS render. Pricing table (which fetches `billing.skus` at build time) renders all rows incl. the CDN price.

## Notes
- macOS caveat: Hugo stopped publishing `.tar.gz` macOS builds (`.pkg` only) around v0.145, and the pinned asdf plugin (`nklmilojevic/asdf-hugo`) only fetches `.tar.gz`, so `asdf install` can't fetch 0.161.1 on macOS. **Cloudflare Pages (Linux) is unaffected** — `hugo_extended_0.161.1_linux-amd64.tar.gz` exists. Local macOS devs need to obtain the binary another way (e.g. extract from the official `.pkg`) until the plugin is updated.
- A stale `resources.GetRemote` cache locally can serve an old `billing.skus` shape; build with `--ignoreCache` if you hit `mul` errors on missing fields. Not an issue in clean CI builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)