### PR TITLE
Remove CDN row from the pricing table

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -263,15 +263,6 @@
 						</td>
 						<td>-</td>
 					</tr>
-						<tr>
-							<td><strong>CDN</strong></td>
-							<td>1 Domain</td>
-							<td>
-								<div><strong>฿{{mul $p.domainCdn $m | lang.FormatNumber 2}}/mo</strong></div>
-								<div>฿{{$p.domainCdn | lang.FormatNumber 10 | strings.TrimRight "0"}}/s</div>
-							</td>
-							<td>-</td>
-						</tr>
 					</tbody>
 				</table>
 			</div>


### PR DESCRIPTION
## What

CDN is no longer a per-domain billed line item — it's included with every domain where the location's edge supports it. The `billing.skus` API response no longer carries `domainCdn` (see deploys-app/apiserver#88), so the homepage pricing table's CDN row (which referenced `$p.domainCdn`) is removed before it would otherwise break the Hugo build's remote fetch.

## Changes

- `layouts/index.html` — dropped the `CDN` pricing row.

## Verify

`hugo --minify` builds clean; no `domainCdn` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)