### PR TITLE
chore: drop Cloudflare Pages references and _hyperscript

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Marketing site for Deploys.app (a Kubernetes-based PaaS), built with **Hugo extended 0.161.1** (pinned via `.tool-versions` — use `asdf install`). Deploys as a static site to Cloudflare Pages (see `static/_headers`).
+Marketing site for Deploys.app (a Kubernetes-based PaaS), built with **Hugo extended 0.161.1** (pinned via `.tool-versions` — use `asdf install`). Deploys as a static site (see `static/_headers`).
 
 ## Commands
 
@@ -40,9 +40,7 @@ When adding styles, write a semantic class in the relevant SCSS file and referen
 
 ### Interactivity
 
-No bundler, no framework. Two scripts are used:
-- **hyperscript** (loaded from unpkg in `baseof.html`) — inline `_="on click ..."` attributes drive small interactions (e.g. navbar toggle in `layouts/partials/navbar.html`).
-- A small inline `<script>` in `navbar.html` adds the scroll-fixed navbar behavior.
+No bundler, no framework. A small inline `<script>` in `layouts/partials/navbar.html` handles all interactions — the mobile menu toggle, closing the menu on link clicks, and the scroll-fixed navbar behavior — using plain DOM APIs.
 
 ### Icons
 
@@ -50,4 +48,4 @@ Icons are **inline SVG**, not a web font. The `icon` partial reads `assets/icons
 
 ### Static assets and caching
 
-Long-lived assets go through Hugo's pipeline with `resources.Fingerprint` (cache-busted filenames). `static/_headers` sets `cache-control: public, max-age=31536000, immutable` for `/image/*`, `/style/*`, `/fonts/*` and adds `x-robots-tag: noindex` to `*.pages.dev` preview URLs — keep that header in place so previews stay out of search indexes.
+Long-lived assets go through Hugo's pipeline with `resources.Fingerprint` (cache-busted filenames). `static/_headers` sets `cache-control: public, max-age=31536000, immutable` for `/image/*`, `/style/*`, `/fonts/*`.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,6 @@
 <meta name="description" content="Deploys.app is a Kubernetes-based platform-as-a-service for running containerized workloads in the cloud.">
 <link rel="icon" type="image/webp" href="/favicon.webp">
 <link rel="icon" type="image/png" href="/favicon.png">
-<script src="https://unpkg.com/hyperscript.org@0.9.12/dist/_hyperscript.min.js" defer></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@300..800&family=JetBrains+Mono:wght@400..600&display=swap">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -3,8 +3,7 @@
 		<a href="/">
 			<img src="{{ (resources.Get "image/logo.webp" | resources.Fingerprint).RelPermalink }}" height="50" alt="Deploys.app">
 		</a>
-		<div id="nav-toggle" class="navbar-toggle" tabindex="0" role="button"
-			 _="on click toggle .active on #nav-menu-container">
+		<div id="nav-toggle" class="navbar-toggle" tabindex="0" role="button">
 			<div class="navbar-toggle-container">
 				{{ partial "icon" "light/bars" }}
 			</div>
@@ -12,29 +11,20 @@
 		<div id="nav-menu-container" class="navbar-menu-container">
 			<ul class="navbar-menus">
 				<li class="navbar-menu">
-					<a class="nav-link"
-					   href="/"
-					   _="on click remove .active from #nav-menu-container">Home</a>
+					<a class="nav-link" href="/">Home</a>
 				</li>
 				<li class="navbar-menu">
-					<a class="nav-link"
-					   href="/#feature"
-					   _="on click remove .active from #nav-menu-container">Features</a>
+					<a class="nav-link" href="/#feature">Features</a>
 				</li>
 				<li class="navbar-menu">
-					<a class="nav-link"
-					   href="/#price"
-					   _="on click remove .active from #nav-menu-container">Prices</a>
+					<a class="nav-link" href="/#price">Prices</a>
 				</li>
 				<li class="navbar-menu">
-					<a class="nav-link"
-					   href="/privacy-policy">Privacy</a>
+					<a class="nav-link" href="/privacy-policy">Privacy</a>
 				</li>
 				<li class="navbar-menu">
 					<div class="navbar-cta">
-						<a class="button -small"
-						   href="https://console.deploys.app"
-						   _="on click remove .active from #nav-menu-container">Console</a>
+						<a class="button -small" href="https://console.deploys.app">Console</a>
 					</div>
 				</li>
 			</ul>
@@ -45,7 +35,18 @@
 <script>
 	document.addEventListener('DOMContentLoaded', () => {
 		const nav = document.getElementById('nav')
+		const toggle = document.getElementById('nav-toggle')
 		const container = document.getElementById('nav-menu-container')
+
+		toggle.addEventListener('click', () => {
+			container.classList.toggle('active')
+		})
+
+		container.querySelectorAll('.nav-link, .navbar-cta a').forEach((link) => {
+			link.addEventListener('click', () => {
+				container.classList.remove('active')
+			})
+		})
 
 		let fixed = false
 		let scrolling = false

--- a/static/_headers
+++ b/static/_headers
@@ -1,5 +1,3 @@
-https://:project.pages.dev/*
-  x-robots-tag: noindex
 /*
   x-frame-options: DENY
   strict-transport-security: max-age=31536000; includeSubDomains; preload


### PR DESCRIPTION
## Summary

Two cleanups bundled together, both done in one session:

- **Drop Cloudflare Pages references.** The site is no longer hosted on Cloudflare Pages, so this removes the "Cloudflare Pages" mention and the `*.pages.dev` preview-URL references from `CLAUDE.md`, plus the `https://:project.pages.dev/*` `x-robots-tag: noindex` block from `static/_headers`.
- **Replace `_hyperscript` with plain JS.** Removes the unpkg `_hyperscript.min.js` `<script>` tag and the inline `_="on click ..."` attributes in the navbar. The mobile menu toggle and "close menu on link click" behavior now live in the existing inline `<script>` in `navbar.html`, using plain DOM APIs.

## Notes

- The `x-robots-tag: noindex` rule for `*.pages.dev` previews is gone since that hosting is no longer used.
- Behavioral nuance: the old markup didn't close the mobile menu when **Privacy** was clicked (it lacked the `_` attribute); the new JS closes the menu on any nav-link click, which is more consistent and harmless (Privacy navigates to a separate page).
- `make build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)