### PR TITLE
ci: update actions/checkout to v6

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: deploys-app/build-deploy-action@v1
       with:
         project: deploys-app


### PR DESCRIPTION
Bump `actions/checkout` from `@v4` to `@v6` in the deploy workflow — latest is **v6.0.3** (2026-06-02). Pinned to the major moving tag, consistent with the other action pins (`build-deploy-action@v1`). Mirrors deploys-app/docs#18.

Only one occurrence (`.github/workflows/deploy.yaml:16`); no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)