### PR TITLE
feat: add static site storage to the pricing table

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -256,6 +256,12 @@
 							<td class="num"><span class="note">—</span></td>
 						</tr>
 						<tr>
+							<td class="res">Static Site Storage</td>
+							<td>1 GiB</td>
+							<td class="num"><div class="price-main">฿{{ $p.staticStorage | lang.FormatNumber 2 }}/mo</div></td>
+							<td class="num"><span class="free">1 GiB</span></td>
+						</tr>
+						<tr>
 							<td class="res">Replica</td>
 							<td>1</td>
 							<td class="num">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -271,7 +271,7 @@
 							<td class="num"><span class="free">{{ 216000 | lang.FormatNumber 0 }} s</span></td>
 						</tr>
 						<tr>
-							<td class="res">Egress Bandwidth</td>
+							<td class="res">Egress</td>
 							<td>1 GiB</td>
 							<td class="num"><div class="price-main">฿{{ $p.egress | lang.FormatNumber 2 }}</div></td>
 							<td class="num">


### PR DESCRIPTION
Two tweaks to the pricing table.

**1. Add static site storage** — the `static_storage` SKU was merged into billing (`PriceStaticStorage = 1 // GiB-month`). New **Static Site Storage** row: ฿1.00/mo per GiB (live from `$p.staticStorage`), 1 GiB daily free tier (matches the apiserver `freeTier` map), placed next to SSD Disk.

**2. Rename "Egress Bandwidth" → "Egress"** — consistent with the sibling rows (Registry Egress, Dropbox Egress) and the docs billing table; the unit column already says GiB.

![pricing](https://raw.githubusercontent.com/deploys-app/website/screenshots/20-pricing.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)