### PR TITLE
Fix horizontal scroll for pricing table on small screens

### DIFF
--- a/assets/style/_components.scss
+++ b/assets/style/_components.scss
@@ -318,7 +318,9 @@ a.card:hover {
 .price-table-wrap {
 	border: 1px solid var(--color-line);
 	border-radius: var(--radius-lg);
-	overflow: hidden;
+	overflow-x: auto;
+	overflow-y: hidden;
+	-webkit-overflow-scrolling: touch;
 	box-shadow: var(--shadow-panel);
 	background: var(--color-base);
 }


### PR DESCRIPTION
## Problem

On small/mobile screens, the pricing table couldn't be scrolled to the right. The `.price-table-wrap` container used `overflow: hidden` (needed to clip its rounded corners), which also blocked horizontal scrolling. When the table exceeded the viewport width — the `Price` and `Free tier` columns use `white-space: nowrap` — there was no way to see the cut-off content.

## Fix

Change `.price-table-wrap` from `overflow: hidden` to `overflow-x: auto` (keeping `overflow-y: hidden` so the rounded-corner clip is preserved), and add `-webkit-overflow-scrolling: touch` for momentum scrolling on iOS.

This is a small semantic SCSS change in `assets/style/_components.scss`; no markup changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1KoH2AxFgNYub3PGaZ7uX)_