### PR TITLE
fix(home): retitle TCP Service card to Internal TCP Service

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -49,8 +49,8 @@
 				</div>
 				<div class="card">
 					<span class="card-icon">{{ partial "icon" "network" }}</span>
-					<span class="card-title">TCP Service</span>
-					<span class="card-desc">Run internal TCP services that talk to each other inside your private network.</span>
+					<span class="card-title">Internal TCP Service</span>
+					<span class="card-desc">Run databases, caches, and other TCP services reachable only inside your project's cluster.</span>
 				</div>
 				<div class="card">
 					<span class="card-icon">{{ partial "icon" "cog" }}</span>


### PR DESCRIPTION
## What

External **TCP Service** (`TCPService`) is no longer offered — the platform can't give users a dedicated external IP + port. The homepage "TCP Service" feature card therefore advertised an **unsupported** feature. (Its original copy even described the *internal* variant under that title.)

Retitle the card to **Internal TCP Service** and describe what actually ships:

> Run databases, caches, and other TCP services reachable only inside your project's cluster.

This is the `InternalTCPService` type — a ClusterIP with no dedicated external IP/port, so it's unaffected by the external-TCP removal. Keeping the card (retitled) preserves the 6-card grid while advertising only a supported capability.

## Scope

- Text-only change to the existing card — no Hugo partial/template, layout, or SCSS change.
- `hugo` extended build clean (5 pages); rendered `public/index.html` shows the new title + description, and no longer mentions external TCP Service.
- **Docs** (`content/deployments/types.md` etc.) still describe external TCP Service as supported — those are updated in a **separate docs PR** (this repo is website-only).

## Why this replaces the earlier reword

An earlier version of this PR reworded the card to accurately describe *external* TCP Service. That's wrong now that the feature is gone — the card is retitled to the still-supported internal type instead.