### PR TITLE
pricing: add Dropbox Storage row to the homepage price table

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -262,6 +262,12 @@
 							<td class="num"><span class="free">1 GiB</span></td>
 						</tr>
 						<tr>
+							<td class="res">Dropbox Storage</td>
+							<td>1 GiB</td>
+							<td class="num"><div class="price-main">฿{{ $p.dropboxStorage | lang.FormatNumber 2 }}/mo</div></td>
+							<td class="num"><span class="note">—</span></td>
+						</tr>
+						<tr>
 							<td class="res">Replica</td>
 							<td>1</td>
 							<td class="num">


### PR DESCRIPTION
## What
Add a **Dropbox Storage** row to the homepage pricing table. Renders `$p.dropboxStorage` directly as a `/mo` value (already per-GiB·month, unlike the per-second SSD Disk/CPU/Memory rows); free tier "—".

## Deploy order
`$p` is fetched at build time from `https://api.deploys.app/billing.skus`. **Rebuild only after apiserver ships the new SKU** (api#125 → apiserver) — otherwise `$p.dropboxStorage` is nil and the row renders `฿0.00/mo`. Same pattern as Static Site Storage.

Verified: `hugo` build clean.

## Screenshots

Homepage pricing table — **before** (no row) vs **after** (new **Dropbox Storage** row at ฿10.37/mo, matching SSD Disk):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/deploys-app/website/screenshots/24-before.png) | ![after](https://raw.githubusercontent.com/deploys-app/website/screenshots/24-after.png) |
